### PR TITLE
ci: replace `actions-rs/toolchain` with `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.0
       - run: cargo check
       - run: cargo fmt --all --check
@@ -27,11 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
+      # https://github.com/dtolnay/rust-toolchain/issues/29
+      - run: rustup override set nightly
       - name: Set grcov version
         run: echo "GRCOV_VERSION=$(cargo search --limit 1 grcov | head -n1 | cut -d '"' -f2)" >> $GITHUB_ENV
       - run: cargo install --version $GRCOV_VERSION grcov
@@ -58,10 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.0
       - run: cargo install cargo-sort
       - run: cargo-sort --check

--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,7 @@ if [ -z "$1" ]; then
     exit
 fi
 
-branch_name=`echo ${1} | sed 's/\.//g'`
+branch_name=$(echo "${1}" | sed 's/\.//g')
 git checkout -b "release_${branch_name}"
 
 # Update the version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59.0"
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 /// A package representation.
 pub struct Package<'a> {
     owner: Option<&'a str>,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,7 @@
 use crate::Result;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Eq)]
 pub struct Version(semver::Version);
 
 impl Version {


### PR DESCRIPTION
Because `actions-rs` [is unmaintained](https://github.com/actions-rs/toolchain/issues/216).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] Tests for the changes have been added (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
