### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -24,7 +24,7 @@ impl<'a> VersionFile<'a> {
         let metadata = match fs::metadata(&self.path) {
             Ok(meta) => meta,
             Err(e) if e.kind() == ErrorKind::NotFound => {
-                self.write_version(&self.version)?;
+                self.write_version(self.version)?;
                 return Ok(Duration::ZERO);
             }
             Err(e) => return Err(e.into()),
@@ -36,7 +36,7 @@ impl<'a> VersionFile<'a> {
 
     pub(crate) fn recreate_file(&self) -> io::Result<()> {
         fs::remove_file(&self.path)?;
-        self.write_version(&self.version)
+        self.write_version(self.version)
     }
 
     pub(crate) fn write_version<V: AsRef<str>>(&self, version: V) -> io::Result<()> {


### PR DESCRIPTION
```
warning: the borrowed expression implements the required traits
  --> src/version_file.rs:27:36
   |
27 |                 self.write_version(&self.version)?;
   |                                    ^^^^^^^^^^^^^ help: change this to: `self.version`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] Tests for the changes have been added (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
