### PR TITLE
feat(get_latest_version): support current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ You can implement your own registry to check updates. For example:
 
 ```rust
 use std::time::Duration;
-use update_informer::{registry, Check, Package, Registry, Result};
+use update_informer::{registry, Check, Package, Registry, Result, Version};
 
 struct YourOwnRegistry;
 
 impl Registry for YourOwnRegistry {
     const NAME: &'static str = "your_own_registry";
 
-    fn get_latest_version(pkg: &Package, _timeout: Duration) -> Result<Option<String>> {
+    fn get_latest_version(pkg: &Package, _current_version: &Version, _timeout: Duration) -> Result<Option<String>> {
         let url = format!("https://your_own_registry.com/{}/latest-version", pkg);
         let result = ureq::get(&url).call()?.into_string()?;
         let version = result.trim().to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,14 +119,14 @@
 //!
 //! ```rust
 //! use std::time::Duration;
-//! use update_informer::{registry, Check, Package, Registry, Result};
+//! use update_informer::{registry, Check, Package, Registry, Result, Version};
 //!
 //! struct YourOwnRegistry;
 //!
 //! impl Registry for YourOwnRegistry {
 //!     const NAME: &'static str = "your_own_registry";
 //!
-//!     fn get_latest_version(pkg: &Package, _timeout: Duration) -> Result<Option<String>> {
+//!     fn get_latest_version(pkg: &Package, _current_version: &Version, _timeout: Duration) -> Result<Option<String>> {
 //!         let url = format!("https://your_own_registry.com/{}/latest-version", pkg);
 //!         let result = ureq::get(&url).call()?.into_string()?;
 //!         let version = result.trim().to_string();
@@ -197,11 +197,12 @@
 //! [`serde`]: https://github.com/serde-rs/serde
 
 #[doc = include_str!("../README.md")]
-use crate::{version::Version, version_file::VersionFile};
+use crate::{version_file::VersionFile};
 use std::time::Duration;
 
 pub use package::Package;
 pub use registry::Registry;
+pub use version::Version;
 
 mod http;
 mod package;
@@ -346,10 +347,11 @@ impl<R: Registry, N: AsRef<str>, V: AsRef<str>> Check for UpdateInformer<R, N, V
     /// ```
     fn check_version(&self) -> Result<Option<Version>> {
         let pkg = Package::new(self.name.as_ref());
+        let current_version = Version::parse(self.version.as_ref())?;
 
         // If the interval is zero, don't use the cache file
         let latest_version = if self.interval.is_zero() {
-            match R::get_latest_version(&pkg, self.timeout)? {
+            match R::get_latest_version(&pkg, &current_version, self.timeout)? {
                 Some(v) => v,
                 None => return Ok(None),
             }
@@ -361,7 +363,7 @@ impl<R: Registry, N: AsRef<str>, V: AsRef<str>> Check for UpdateInformer<R, N, V
                 // This is needed to update mtime of the file
                 latest_version_file.recreate_file()?;
 
-                match R::get_latest_version(&pkg, self.timeout)? {
+                match R::get_latest_version(&pkg, &current_version, self.timeout)? {
                     Some(v) => {
                         latest_version_file.write_version(&v)?;
                         v
@@ -374,7 +376,6 @@ impl<R: Registry, N: AsRef<str>, V: AsRef<str>> Check for UpdateInformer<R, N, V
         };
 
         let latest_version = Version::parse(latest_version)?;
-        let current_version = Version::parse(self.version.as_ref())?;
 
         if latest_version > current_version {
             return Ok(Some(latest_version));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@
 //! [`serde`]: https://github.com/serde-rs/serde
 
 #[doc = include_str!("../README.md")]
-use crate::{version_file::VersionFile};
+use crate::version_file::VersionFile;
 use std::time::Duration;
 
 pub use package::Package;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::{Package, Result};
+use crate::{Package, Result, Version};
 use std::time::Duration;
 
 #[cfg(feature = "crates")]
@@ -28,5 +28,5 @@ pub trait Registry {
     /// # Arguments
     ///
     /// * `pkg` - A `Package` struct.
-    fn get_latest_version(pkg: &Package, timeout: Duration) -> Result<Option<String>>;
+    fn get_latest_version(pkg: &Package, current_version: &Version, timeout: Duration) -> Result<Option<String>>;
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -28,5 +28,9 @@ pub trait Registry {
     /// # Arguments
     ///
     /// * `pkg` - A `Package` struct.
-    fn get_latest_version(pkg: &Package, current_version: &Version, timeout: Duration) -> Result<Option<String>>;
+    fn get_latest_version(
+        pkg: &Package,
+        current_version: &Version,
+        timeout: Duration,
+    ) -> Result<Option<String>>;
 }

--- a/src/registry/crates.rs
+++ b/src/registry/crates.rs
@@ -34,7 +34,11 @@ fn get_base_url() -> String {
 impl Registry for Crates {
     const NAME: &'static str = "crates";
 
-    fn get_latest_version(pkg: &Package, _current_version: &Version, timeout: Duration) -> Result<Option<String>> {
+    fn get_latest_version(
+        pkg: &Package,
+        _current_version: &Version,
+        timeout: Duration,
+    ) -> Result<Option<String>> {
         let url = format!("{}/{}/versions", get_base_url(), pkg);
 
         let resp: Response = http::get(&url, timeout).call()?;

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -29,7 +29,11 @@ fn get_base_url() -> String {
 impl Registry for GitHub {
     const NAME: &'static str = "github";
 
-    fn get_latest_version(pkg: &Package, current_version: &Version, timeout: Duration) -> Result<Option<String>> {
+    fn get_latest_version(
+        pkg: &Package,
+        _current_version: &Version,
+        timeout: Duration,
+    ) -> Result<Option<String>> {
         let url = format!("{}/{}/releases/latest", get_base_url(), pkg);
         let resp: Response = http::get(&url, timeout)
             .add_header("Accept", "application/vnd.github.v3+json")

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -1,4 +1,4 @@
-use crate::{http, Package, Registry, Result};
+use crate::{http, Package, Registry, Result, Version};
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -29,9 +29,8 @@ fn get_base_url() -> String {
 impl Registry for GitHub {
     const NAME: &'static str = "github";
 
-    fn get_latest_version(pkg: &Package, timeout: Duration) -> Result<Option<String>> {
+    fn get_latest_version(pkg: &Package, current_version: &Version, timeout: Duration) -> Result<Option<String>> {
         let url = format!("{}/{}/releases/latest", get_base_url(), pkg);
-
         let resp: Response = http::get(&url, timeout)
             .add_header("Accept", "application/vnd.github.v3+json")
             .call()?;
@@ -58,8 +57,9 @@ mod tests {
         let pkg = Package::new(PKG_NAME);
         let data_path = format!("{}/not_found.json", FIXTURES_PATH);
         let _mock = mock_github(&pkg, 404, &data_path);
+        let current_version = Version::parse("0.1.0").expect("parse version");
 
-        let result = GitHub::get_latest_version(&pkg, TIMEOUT);
+        let result = GitHub::get_latest_version(&pkg, &current_version, TIMEOUT);
         assert!(result.is_err());
     }
 
@@ -71,8 +71,9 @@ mod tests {
 
         let json: Response = serde_json::from_str(&data).expect("deserialize json");
         let latest_version = json.tag_name[1..].to_string();
+        let current_version = Version::parse("1.6.3-canary.0").expect("parse version");
 
-        let result = GitHub::get_latest_version(&pkg, TIMEOUT);
+        let result = GitHub::get_latest_version(&pkg, &current_version, TIMEOUT);
 
         assert!(result.is_ok());
         assert_eq!(result.expect("get result"), Some(latest_version));

--- a/src/registry/pypi.rs
+++ b/src/registry/pypi.rs
@@ -32,7 +32,11 @@ fn get_base_url() -> String {
 impl Registry for PyPI {
     const NAME: &'static str = "pypi";
 
-    fn get_latest_version(pkg: &Package, _current_version: &Version, timeout: Duration) -> Result<Option<String>> {
+    fn get_latest_version(
+        pkg: &Package,
+        _current_version: &Version,
+        timeout: Duration,
+    ) -> Result<Option<String>> {
         let url = format!("{}/{}/json", get_base_url(), pkg);
 
         let resp: Response = http::get(&url, timeout).call()?;

--- a/src/version.rs
+++ b/src/version.rs
@@ -13,7 +13,7 @@ impl Version {
         Ok(Self(version))
     }
 
-    pub(crate) fn get(&self) -> &semver::Version {
+    pub fn get(&self) -> &semver::Version {
         &self.0
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -12,6 +12,10 @@ impl Version {
 
         Ok(Self(version))
     }
+
+    pub(crate) fn get(&self) -> &semver::Version {
+        &self.0
+    }
 }
 
 impl Display for Version {


### PR DESCRIPTION
Hello! Thanks for the awesome library. We're planning to use this with https://github.com/vercel/turbo, but we have an additional requirement that I'm hoping we can include here. 

We implemented a custom registry (ultimately it goes NPM, but with an intermediate edge function for performance reasons), and we want to be able to make a different API request depending on the users distribution. For example, if a user is on a canary (example version may be: `1.7.0-canary.0`) we would want to alert them about new canary versions. However, if a user is on the latest distribution (`1.6.3`), we would only want to check for new versions under the `latest` tag.

This PR extends the `get_latest_version` API to add a second parameter, `current_version: &Version`. This allows the user to inspect the current version (via something like `current_version.get().pre`) to determine what API request to make. 

Happy to write more tests or docs if you think this is worthwhile, thank you!

#### ✔ Checklist:
- [X] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [X] Tests for the changes have been added (for bug fixes / features).
