### PR TITLE
chore: add example declarations for examples that have required features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,18 @@ colored = "2.0"
 isahc = { version = "1.7", features = ["json"] }
 mockito = "0.31"
 once_cell = "1.10"
+
+[[example]]
+name = "github"
+path = "examples/github.rs"
+required-features = ["github"]
+
+[[example]]
+name = "npm"
+path = "examples/npm.rs"
+required-features = ["npm"]
+
+[[example]]
+name = "pypi"
+path = "examples/pypi.rs"
+required-features = ["pypi"]


### PR DESCRIPTION
First off, thanks for the great project! I wanted to quick add examples to the manifest where a feature is required for it to compile. It offers a slightly better error message:
```
olszewski@chriss-mbp update-informer % cargo run --example github
error: target `github` in package `update-informer` requires the features: `github`
Consider enabling them by passing, e.g., `--features="github"`
```
vs
```
olszewski@chriss-mbp update-informer % cargo run --example github
   Compiling update-informer v0.6.0 (/Users/olszewski/code/update-informer)
error[E0425]: cannot find value `GitHub` in module `registry`
 --> examples/github.rs:9:40
  |
9 |         update_informer::new(registry::GitHub, pkg_name, current_version).interval(Duration::ZERO);
  |                                        ^^^^^^ not found in `registry`

For more information about this error, try `rustc --explain E0425`.
error: could not compile `update-informer` due to previous error
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
