### PR TITLE
chore: made Cargo.toml and readme less CLI-centric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,16 @@
 name = "update-informer"
 version = "1.1.0" # managed by release.sh
 authors = ["Mikhail Grachev <work@mgrachev.com>"]
-categories = ["command-line-interface"]
+categories = ["web-programming", "caching"]
 documentation = "https://docs.rs/update-informer"
 edition = "2021"
 homepage = "https://github.com/mgrachev/update-informer"
 include = ["/src", "README.md"]
-keywords = ["cli", "update", "informer", "notifier", "github"]
+keywords = ["update", "version-check", "notifier", "github", "cli"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/mgrachev/update-informer"
-description = "Update informer for CLI applications"
+description = "Easily implement update checks for your application"
 
 [features]
 default = ["crates", "ureq", "rustls-tls"]

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@
      alt="update-informer"
      src="https://raw.githubusercontent.com/mgrachev/update-informer/main/logo.svg?sanitize=true">
 
-Update informer for CLI applications written in Rust 🦀
+Update informer for applications written in Rust 🦀
 
-It checks for a new version on Crates.io, GitHub, Npm and PyPI 🚀
+It checks for a new version on Crates.io, GitHub, Npm and PyPI. 🚀
 
 ## Benefits
 


### PR DESCRIPTION
As touched on in #142.

# Regarding `Cargo.toml` changes to `categories`

See also:

- https://crates.io/category_slugs
- https://crates.io/categories

The category "command-line-interface" IMO doesn't fit ("Crates to help create command line interfaces, such as argument parsers, line-editing, or output coloring and formatting"), just like "gui" doesn't fit ("Crates to help you create a graphical user interface").

When you read the description for the category "web-programming" - "Crates to create applications for the web" - you may also think that it doesn't fit. But look at the descriptions of the subcategories:

> web-programming::http-client
> &nbsp;&nbsp;&nbsp;&nbsp;Crates to make HTTP network requests.
>
> web-programming::http-server
> &nbsp;&nbsp;&nbsp;&nbsp;Crates to serve data over HTTP.
>
> web-programming::websocket
> &nbsp;&nbsp;&nbsp;&nbsp;Crates to communicate over the WebSocket protocol.

These subcategories put "web-programming" in the light of "Crates to create applications augmented with web functionality". And this fits perfectly.

# Other

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- *Not applicable:* [ ] Tests for the changes have been added (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
