### PR TITLE
chore: use etcetera instead of directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustls-tls = ["ureq?/tls", "reqwest?/rustls-tls"]
 native-tls = ["ureq?/native-tls", "reqwest?/native-tls"]
 
 [dependencies]
-directories = "5.0"
+etcetera = "0.8.0"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [codecov-badge]: https://codecov.io/gh/mgrachev/update-informer/branch/main/graph/badge.svg?token=A4XD1DGFGJ
 [codecov-url]: https://codecov.io/gh/mgrachev/update-informer
 [downloads-badge]: https://img.shields.io/crates/d/update-informer
-[directories]: https://github.com/dirs-dev/directories-rs
+[etcetera]: https://github.com/lunacookies/etcetera 
 [ureq]: https://github.com/algesten/ureq
 [semver]: https://github.com/dtolnay/semver
 [serde]: https://github.com/serde-rs/serde
@@ -47,7 +47,7 @@ It checks for a new version on Crates.io, GitHub, Npm and PyPI. 🚀
 - Configurable [check frequency](#interval) and [request timeout](#request-timeout).
 - [Caching](#caching) the results of checking updates.
 - Ability to implement your own [registry](#implementing-your-own-registry) or [http client](#using-your-own-http-client).
-- **Minimum dependencies** - only [directories], [semver], [serde] and an HTTP client ([ureq] or [reqwest]).
+- **Minimum dependencies** - only [etcetera], [semver], [serde] and an HTTP client ([ureq] or [reqwest]).
 
 ## Idea
 

--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -50,9 +50,10 @@ impl<'a> VersionFile<'a> {
 
 #[cfg(not(test))]
 fn cache_path() -> Result<PathBuf> {
-    let project_dir = directories::ProjectDirs::from("", "", "update-informer-rs")
-        .ok_or("Unable to find cache directory")?;
-    let directory = project_dir.cache_dir().to_path_buf();
+    use etcetera::BaseStrategy;
+    let base_dir =
+        etcetera::choose_base_strategy().map_err(|_| "Unable to find cache directory")?;
+    let directory = base_dir.cache_dir().join("update-informer-rs");
     fs::create_dir_all(&directory)?;
     Ok(directory)
 }


### PR DESCRIPTION
Resolves #138

Hi, this project is very cool. I found issue which I may solve so I try to.

## About possibility to change of cache dir
In my mac, cache directory was changed like below by this change. I can't test on Windows and Linux, but there is a possibility that cache dir on these OS can changed. Is this acceptable?

| Before | After |
|--------|--------|
| `${HOME}/.cache/update-informer-rs` | `${HOME}/Library/Caches/update-informer-rs` |

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Commit messages have been written in [Conventional Commits](https://www.conventionalcommits.org) format;
- [ ] Tests for the changes have been added (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
